### PR TITLE
Add core

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,3 +41,10 @@ about:
 extra:
   recipe-maintainers:
     - jakirkham
+    - jjhelmus
+    - msarahan
+    - mwcraig
+    - ocefpaf
+    - patricksnape
+    - pelson
+    - scopatz


### PR DESCRIPTION
Gives @conda-forge/core permissions on this feedstock.

Note: This is a dependency of `conda-build`.